### PR TITLE
Avoid installing dependencies on every run

### DIFF
--- a/install.py
+++ b/install.py
@@ -14,4 +14,5 @@ def ensure_package():
     cmds = build_pip_install_cmds(['-r', 'requirements.txt'])
     subprocess.run(cmds, cwd=custom_nodes_path)
 
-ensure_package()
+if __name__ == "__main__":
+    ensure_package()


### PR DESCRIPTION
It looks like the `install.py` is imported from `__init__.py`, which means every time this plugin is loaded, it'll trigger a bunch of `pip install`s because `ensure_package` is called from the module's top level. At best, it just slows down ComfyUI start, at worst it messes up some dependencies.

This PR wraps the call to `ensure_package()` into Python's idiomatic way of making sure it's being executed as a script (vs required as a module). Alternatively, we could remove the `from .install import *` line from `__init__.py`.

Another option is to remove `install.py` altogether — `ComfyUI-Manager` already supports `requirements.txt` and it doesn't seem like this `install.py` does anything different.